### PR TITLE
Rename Bridge.contribute() to bind()

### DIFF
--- a/integration-test/src/test/java/org/hibernate/search/v6poc/JavaBeanElasticsearchExtensionIT.java
+++ b/integration-test/src/test/java/org/hibernate/search/v6poc/JavaBeanElasticsearchExtensionIT.java
@@ -194,7 +194,7 @@ public class JavaBeanElasticsearchExtensionIT {
 		private IndexFieldAccessor<String> fieldAccessor;
 
 		@Override
-		public void contribute(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
+		public void bind(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
 				SearchModel searchModel) {
 			sourceAccessor = bridgedPojoModelElement.createAccessor( String.class );
 			fieldAccessor = indexSchemaElement.field( "jsonStringField" )

--- a/integration-test/src/test/java/org/hibernate/search/v6poc/JavaBeanElasticsearchIT.java
+++ b/integration-test/src/test/java/org/hibernate/search/v6poc/JavaBeanElasticsearchIT.java
@@ -766,7 +766,7 @@ public class JavaBeanElasticsearchIT {
 		}
 
 		@Override
-		public void contribute(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
+		public void bind(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
 				SearchModel searchModel) {
 			sourceAccessor = bridgedPojoModelElement.createAccessor( IndexedEntity.class );
 			IndexSchemaObjectField objectField = indexSchemaElement.objectField( objectName );

--- a/integration-test/src/test/java/org/hibernate/search/v6poc/JavaBeanElasticsearchObjectFieldIT.java
+++ b/integration-test/src/test/java/org/hibernate/search/v6poc/JavaBeanElasticsearchObjectFieldIT.java
@@ -208,7 +208,7 @@ public class JavaBeanElasticsearchObjectFieldIT {
 		}
 
 		@Override
-		public void contribute(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
+		public void bind(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
 				SearchModel searchModel) {
 			sourceAccessor = bridgedPojoModelElement.createAccessor( List.class );
 			IndexSchemaObjectField objectField = indexSchemaElement.objectField( objectName );

--- a/integration-test/src/test/java/org/hibernate/search/v6poc/JavaBeanElasticsearchObjectFieldInvalidDocumentElementIT.java
+++ b/integration-test/src/test/java/org/hibernate/search/v6poc/JavaBeanElasticsearchObjectFieldInvalidDocumentElementIT.java
@@ -152,7 +152,7 @@ public class JavaBeanElasticsearchObjectFieldInvalidDocumentElementIT {
 		}
 
 		@Override
-		public void contribute(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
+		public void bind(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
 				SearchModel searchModel) {
 			sourceAccessor = bridgedPojoModelElement.createAccessor( String.class );
 			IndexSchemaObjectField objectField = indexSchemaElement.objectField( objectName );

--- a/integration-test/src/test/java/org/hibernate/search/v6poc/OrmElasticsearchIT.java
+++ b/integration-test/src/test/java/org/hibernate/search/v6poc/OrmElasticsearchIT.java
@@ -819,7 +819,7 @@ public class OrmElasticsearchIT {
 		}
 
 		@Override
-		public void contribute(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
+		public void bind(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
 				SearchModel searchModel) {
 			sourceAccessor = bridgedPojoModelElement.createAccessor( IndexedEntity.class );
 			IndexSchemaObjectField objectField = indexSchemaElement.objectField( objectName );

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/Bridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/Bridge.java
@@ -17,7 +17,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
  */
 public interface Bridge extends AutoCloseable {
 
-	void contribute(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
+	void bind(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
 			SearchModel searchModel);
 
 	void write(DocumentElement target, PojoElement source);

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/Bridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/Bridge.java
@@ -9,19 +9,61 @@ package org.hibernate.search.v6poc.entity.pojo.bridge;
 import org.hibernate.search.v6poc.backend.document.DocumentElement;
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaElement;
 import org.hibernate.search.v6poc.entity.model.SearchModel;
-import org.hibernate.search.v6poc.entity.pojo.model.PojoModelElement;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
+import org.hibernate.search.v6poc.entity.pojo.model.PojoModelElement;
 
 /**
+ * A bridge between an element of the POJO model and an element of the index schema.
+ * <p>
+ * The {@code Bridge} interface is a more powerful version of {@link FunctionBridge},
+ * in which a property can be mapped to more than one field, in particular.
+ *
  * @author Yoann Rodiere
  */
 public interface Bridge extends AutoCloseable {
 
+	/**
+	 * Bind this bridge instance to the given index schema element and the given POJO model element.
+	 * <p>
+	 * This method is called exactly once for each bridge instance, before any other method.
+	 * It allows the bridge to:
+	 * <ul>
+	 *     <li>Declare its expectations regarding the POJO model (input type, expected properties and their type, ...).
+	 *     <li>Declare its expectations regarding the index schema (field names and field types, storage options, ...).
+	 *     <li>Retrieve accessors to the POJO and to the index fields that will later be used in the
+	 *     {@link #write(DocumentElement, PojoElement)} method.
+	 *     <li>Optionally, using the {@link SearchModel}, define how to map POJO properties to fields when searching
+	 *     (in predicates and projections).
+	 * </ul>
+	 *
+	 * @param indexSchemaElement An entry point to declaring expectations and retrieving accessors to the index schema.
+	 * @param bridgedPojoModelElement An entry point to declaring expectations and retrieving accessors to the
+	 * bridged POJO model.
+	 * @param searchModel An entry point to defining how to map POJO properties to fields when searching.
+	 */
 	void bind(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
 			SearchModel searchModel);
 
+	/**
+	 * Write to fields in the given {@link DocumentElement},
+	 * using the given {@link PojoElement} as input and transforming it as necessary.
+	 * <p>
+	 * Writing to the {@link DocumentElement} should be done using
+	 * {@link org.hibernate.search.v6poc.backend.document.IndexFieldAccessor}s retrieved when the
+	 * {@link #bind(IndexSchemaElement, PojoModelElement, SearchModel)} method was called.
+	 * <p>
+	 * Reading from the {@link PojoElement} should be done using
+	 * {@link org.hibernate.search.v6poc.entity.pojo.model.PojoModelElementAccessor}s retrieved when the
+	 * {@link #bind(IndexSchemaElement, PojoModelElement, SearchModel)} method was called.
+	 *
+	 * @param target The {@link DocumentElement} to write to.
+	 * @param source The {@link PojoElement} to read from.
+	 */
 	void write(DocumentElement target, PojoElement source);
 
+	/**
+	 * Close any resource before the bridge is discarded.
+	 */
 	@Override
 	default void close() {
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/FunctionBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/FunctionBridge.java
@@ -10,23 +10,58 @@ import org.hibernate.search.v6poc.backend.document.model.FieldModelContext;
 import org.hibernate.search.v6poc.backend.document.model.TypedFieldModelContext;
 
 /**
+ * A bridge between a POJO property of type {@code T} and an index field of type {@code R}.
+ * <p>
+ * The {@code FunctionBridge} interface is a simpler version of {@link Bridge},
+ * in which a given value can only be mapped to a single field, in particular.
+ *
+ * @param <T> The type of values on the POJO side of the bridge.
+ * @param <R> The type of values on the index side of the bridge.
+ *
  * @author Yoann Rodiere
  */
 public interface FunctionBridge<T, R> extends AutoCloseable {
 
+	/**
+	 * Bind this bridge instance to the given index field model.
+	 * <p>
+	 * This method is called exactly once for each bridge instance, before any other method.
+	 * It allows the bridge to declare its expectations regarding the index field (type, storage options, ...).
+	 *
+	 * @param context An entry point to declaring expectations and retrieving accessors to the index schema.
+	 * @return The result provided by {@code context} after setting the expectations regarding the index field
+	 * (for instance {@code return context.asString()}). {@code null} to let Hibernate Search derive the expectations
+	 * from the {@code FunctionBridge}'s generic type parameters.
+	 */
 	default TypedFieldModelContext<R> bind(FieldModelContext context) {
 		return null; // Auto-detect the return type and use default encoding
 	}
 
+	/**
+	 * Transform the given POJO property value to the value of the indexed field.
+	 *
+	 * @param propertyValue The POJO property value to be transformed.
+	 * @return The value of the indexed field.
+	 */
 	R toIndexedValue(T propertyValue);
 
-	/*
-	 * TODO use this method when projecting.
+	/**
+	 * Transform the given indexed field value back to the value of the POJO property,
+	 * or to any implementation-defined value to be returned in projections on the POJO property.
+	 * <p>
+	 * For instance, a {@code FunctionBridge} indexing JPA entities by putting their identifier in a field
+	 * might not be able to retrieve the entity, so it could just return the identifier as-is.
+	 *
+	 * @param fieldValue The field value to be transformed.
+	 * @return The value returned in projections on the POJO property.
 	 */
 	default Object fromIndexedValue(R fieldValue) {
 		return fieldValue;
 	}
 
+	/**
+	 * Close any resource before the bridge is discarded.
+	 */
 	@Override
 	default void close() {
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/IdentifierBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/IdentifierBridge.java
@@ -8,16 +8,36 @@ package org.hibernate.search.v6poc.entity.pojo.bridge;
 
 
 /**
- * Converts an identifier to a unique String representation and back.
+ * A bridge between a POJO property of type {@code T} and a document identifier.
  *
  * @author Yoann Rodiere
  */
 public interface IdentifierBridge<T> extends AutoCloseable {
 
-	String toDocumentIdentifier(T id);
+	/**
+	 * Transform the given POJO property value to the value of the document identifier.
+	 * <p>
+	 * Must return a unique value for each value of {@code propertyValue}
+	 *
+	 * @param propertyValue The POJO property value to be transformed.
+	 * @return The value of the document identifier.
+	 */
+	String toDocumentIdentifier(T propertyValue);
 
-	T fromDocumentIdentifier(String idString);
+	/**
+	 * Transform the given document identifier value back to the value of the POJO property.
+	 * <p>
+	 * Must be the exact inverse function of {@link #toDocumentIdentifier(Object)},
+	 * i.e. {@code object.equals(fromDocumentIdentifier(toDocumentIdentifier(object)))} must always be true.
+	 *
+	 * @param documentIdentifier The document identifier value to be transformed.
+	 * @return The value of the document identifier.
+	 */
+	T fromDocumentIdentifier(String documentIdentifier);
 
+	/**
+	 * Close any resource before the bridge is discarded.
+	 */
 	@Override
 	default void close() {
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/RoutingKeyBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/RoutingKeyBridge.java
@@ -10,14 +10,32 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoModelElement;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
 
 /**
+ * A bridge from a POJO entity to a document routing key.
+ *
  * @author Yoann Rodiere
  */
 public interface RoutingKeyBridge extends AutoCloseable {
 
 	void bind(PojoModelElement pojoModelElement);
 
+	/**
+	 * Generate a routing key using the given {@code tenantIdentifier}, {@code entityIdentifier} and {@link PojoElement}
+	 * as input and transforming them as necessary.
+	 * <p>
+	 * Reading from the {@link PojoElement} should be done using
+	 * {@link org.hibernate.search.v6poc.entity.pojo.model.PojoModelElementAccessor}s retrieved when the
+	 * {@link #bind(PojoModelElement)} method was called.
+	 *
+	 * @param tenantIdentifier The tenant identifier currently in use ({@code null} if none).
+	 * @param entityIdentifier The value of the POJO property used to generate the document identifier,
+	 * i.e. the same value that was passed to {@link IdentifierBridge#toDocumentIdentifier(Object)}.
+	 * @param source The {@link PojoElement} to read from.
+	 */
 	String toRoutingKey(String tenantIdentifier, Object entityIdentifier, PojoElement source);
 
+	/**
+	 * Close any resource before the bridge is discarded.
+	 */
 	@Override
 	default void close() {
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/impl/DefaultIntegerIdentifierBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/impl/DefaultIntegerIdentifierBridge.java
@@ -11,13 +11,13 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.IdentifierBridge;
 public final class DefaultIntegerIdentifierBridge implements IdentifierBridge<Integer> {
 
 	@Override
-	public String toDocumentIdentifier(Integer id) {
-		return id.toString();
+	public String toDocumentIdentifier(Integer propertyValue) {
+		return propertyValue.toString();
 	}
 
 	@Override
-	public Integer fromDocumentIdentifier(String idString) {
-		return Integer.parseInt( idString );
+	public Integer fromDocumentIdentifier(String documentIdentifier) {
+		return Integer.parseInt( documentIdentifier );
 	}
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/spatial/impl/GeoPointBridgeImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/spatial/impl/GeoPointBridgeImpl.java
@@ -43,7 +43,7 @@ public class GeoPointBridgeImpl implements Bridge {
 	}
 
 	@Override
-	public void contribute(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
+	public void bind(IndexSchemaElement indexSchemaElement, PojoModelElement bridgedPojoModelElement,
 			SearchModel searchModel) {
 		if ( fieldName == null || fieldName.isEmpty() ) {
 			// TODO retrieve the default name somehow when parameters.name() is empty

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexModelBinder.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexModelBinder.java
@@ -24,7 +24,7 @@ import org.hibernate.search.v6poc.entity.pojo.processing.impl.ValueProcessor;
  * them.
  * <p>
  * Incidentally, this will also generate the index model,
- * due to bridges contributing to the index model as we contribute them.
+ * due to bridges contributing to the index model as we bind them.
  *
  * @author Yoann Rodiere
  */

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexModelBinderImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexModelBinderImpl.java
@@ -93,7 +93,7 @@ public class PojoIndexModelBinderImpl implements PojoIndexModelBinder {
 		Bridge bridge = builder.build( buildContext );
 
 		// FIXME if all fields are filtered out, we should ignore the processor
-		bridge.contribute( bindingContext.getSchemaElement(), pojoModelElement, bindingContext.getSearchModel() );
+		bridge.bind( bindingContext.getSchemaElement(), pojoModelElement, bindingContext.getSearchModel() );
 
 		return new BridgeValueProcessor( bridge );
 	}


### PR DESCRIPTION
Following my discussion with Sanne.

The name "bind" is admittedly very generic, but it has the advantage of not being misleading, as it does not dismiss any of the purposes of this method. "contribute" would just make it feel like this method is only about outputing information to the schemas, whereas it is also about initializing the bridge so it can actually do something in the `write()` method.

Hopefully a good javadoc will make it clear exactly what we expect from users in this `bind()` method and will offset the generic nature of "bind".